### PR TITLE
Added configuration file for electron-installer-debian

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -11,4 +11,5 @@ electron-packager . \
 electron-installer-debian \
   --src build/Headset-linux-x64/ \
   --dest build/installers/ \
-  --arch amd64
+  --arch amd64 \
+  --config config.json

--- a/config.json
+++ b/config.json
@@ -1,5 +1,4 @@
 {
-  "dest": "build/installer/",
   "icon": "icon.png",
   "categories": [
     "GNOME",

--- a/config.json
+++ b/config.json
@@ -1,0 +1,11 @@
+{
+  "dest": "build/installer/",
+  "icon": "icon.png",
+  "categories": [
+    "GNOME",
+    "GTK",
+    "Audio",
+    "Player",
+    "Music"
+  ]
+}


### PR DESCRIPTION
This configuration file works by adding the option `--config config.jason` to `electron-installer-debian`. The command will look like this based on the current setup: `electron-installer-debian --src build/Headset-linux-x64/ --arch amd64 --config config.json`

This configuration file will fix issue #30 and possibly #35. This will also partially fix issue #46 .
Also, issue #11 was not really fixed, there was only a workaround provided for this issue. It can now be properly closed by this.
Also, there's some mention of the .desktop file in issue 16 which can probably be closed too