### PR TITLE
Various Linux fixes and initial Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
   - cd debian/
   
 before_script:
-  - yarn rebuild
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,10 @@ addons:
       - libdbus-1-dev
       - libglib2.0-dev
       - dbus
-      
+
 before_install:
   - cd debian/
-  
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
-  
+
 script:
   - yarn build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: node_js
+
+node_js: "6"
+
+addons:
+  apt:
+    packages:
+      - xvfb
+      - fakeroot
+      - dpkg
+      - libdbus-1-dev
+      - libglib2.0-dev
+      - dbus
+      
+before_install:
+  - cd debian/
+  
+before_script:
+  - yarn rebuild
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+  
+script:
+  - yarn build
+
+cache:
+  directories:
+  - debian/node_modules

--- a/debian/Procfile
+++ b/debian/Procfile
@@ -1,2 +1,2 @@
-headset: npm run electron
-player: npm run player 
+headset: yarn electron
+player: yarn player 

--- a/debian/bin/build
+++ b/debian/bin/build
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 electron-packager . \
-  --ignore=node_modules/electron-prebuilt \
-  --ignore=node_modules/electron-packager \
+  --ignore bin \
+  --ignore config.json \
+  --packageManager yarn \
   --out build/ \
-  --icon ../icon.png \
   --overwrite \
   --platform=linux \
   --arch=x64

--- a/debian/bin/build
+++ b/debian/bin/build
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 electron-packager . \
   --ignore bin \
   --ignore config.json \

--- a/debian/bin/build
+++ b/debian/bin/build
@@ -3,6 +3,7 @@
 electron-packager . \
   --ignore bin \
   --ignore config.json \
+  --prune true \
   --packageManager yarn \
   --out build/ \
   --overwrite \

--- a/debian/index.js
+++ b/debian/index.js
@@ -1,5 +1,4 @@
 const electron = require('electron');
-const defaultMenu = require('electron-default-menu');
 const { NODE_ENV } = process.env;
 const { version } = require('./package')
 const path = require('path')

--- a/debian/index.js
+++ b/debian/index.js
@@ -33,7 +33,7 @@ const start = () => {
     title: 'Headset',
     maximizable: false,
     titleBarStyle: 'hidden-inset',
-    icon: `file://${__dirname}/icon.png`,
+    icon: `icon.png`,
     frame: true
   });
 

--- a/debian/package.json
+++ b/debian/package.json
@@ -17,7 +17,6 @@
   "author": "Daniel Ravina",
   "dependencies": {
     "dbus": "^1.0.0",
-    "electron-default-menu": "^1.0.1",
     "electron-window-state": "^4.1.1"
   },
   "devDependencies": {

--- a/debian/package.json
+++ b/debian/package.json
@@ -10,7 +10,7 @@
     "player": "./bin/player-window",
     "production": "NODE_ENV=production electron .",
     "build": "NODE_ENV=production NEW_VERSION=$npm_package_version ./bin/build",
-    "rebuild": "electron-rebuild"
+    "install": "electron-rebuild"
   },
   "productName": "Headset",
   "license": "MIT",

--- a/debian/package.json
+++ b/debian/package.json
@@ -17,11 +17,14 @@
   "author": "Daniel Ravina",
   "dependencies": {
     "dbus": "^1.0.0",
+    "electron-default-menu": "^1.0.1",
+    "electron-window-state": "^4.1.1"
+  },
+  "devDependencies": {
     "electron": "^1.6.11",
-    "electron-default-menu": "^0.1.1",
+    "electron-installer-debian": "^0.5.0",
     "electron-packager": "^7.0.2",
     "electron-rebuild": "^1.6.0",
-    "electron-window-state": "^4.1.1",
-    "iconutil": "^1.0.1"
+    "foreman": "^2.0.0"
   }
 }

--- a/debian/package.json
+++ b/debian/package.json
@@ -10,7 +10,7 @@
     "player": "./bin/player-window",
     "production": "NODE_ENV=production electron .",
     "build": "NODE_ENV=production NEW_VERSION=$npm_package_version ./bin/build",
-    "install": "electron-rebuild"
+    "postinstall": "electron-rebuild"
   },
   "productName": "Headset",
   "license": "MIT",

--- a/debian/yarn.lock
+++ b/debian/yarn.lock
@@ -36,13 +36,38 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+array-filter@~0.0.0:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
 
+array-map@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
+
+array-reduce@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
+
 asar@^0.12.0:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/asar/-/asar-0.12.4.tgz#2dd3f116882eab8c0f23b754792a82a7d9fce171"
+  dependencies:
+    chromium-pickle-js "^0.2.0"
+    commander "^2.9.0"
+    cuint "^0.2.1"
+    glob "^6.0.4"
+    minimatch "^3.0.3"
+    mkdirp "^0.5.0"
+    mksnapshot "^0.3.0"
+    tmp "0.0.28"
+
+asar@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/asar/-/asar-0.13.0.tgz#df33dd9d01bff842464d0d9f095740d4a62afb14"
   dependencies:
     chromium-pickle-js "^0.2.0"
     commander "^2.9.0"
@@ -64,6 +89,16 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
 assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+
+async@^1.4.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+
+async@^2.0.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
+  dependencies:
+    lodash "^4.14.0"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -208,6 +243,12 @@ commander@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
+commander@~2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -306,9 +347,9 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-electron-default-menu@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/electron-default-menu/-/electron-default-menu-0.1.1.tgz#d966b32f39a52a1ac6a525f20dbdfc3ce4f6e309"
+electron-default-menu@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/electron-default-menu/-/electron-default-menu-1.0.1.tgz#3173c5018eb507404fec63bdf3b78c38eedba808"
 
 electron-download@^2.0.0:
   version "2.2.1"
@@ -336,6 +377,21 @@ electron-download@^3.0.1:
     rc "^1.1.2"
     semver "^5.3.0"
     sumchecker "^1.2.0"
+
+electron-installer-debian@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/electron-installer-debian/-/electron-installer-debian-0.5.2.tgz#f1a11a3c4f60eb411e06fd929fe6d8d124f9fa06"
+  dependencies:
+    asar "^0.13.0"
+    async "^2.0.0"
+    debug "^2.2.0"
+    fs-extra "^1.0.0"
+    get-folder-size "^1.0.0"
+    glob "^7.0.0"
+    lodash "^4.13.0"
+    temp "^0.8.3"
+    word-wrap "^1.1.0"
+    yargs "^7.0.2"
 
 electron-osx-sign@^0.3.0:
   version "0.3.2"
@@ -406,6 +462,10 @@ escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+eventemitter3@1.x.x:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
+
 extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -435,6 +495,15 @@ find-up@^1.0.0:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
+
+foreman@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/foreman/-/foreman-2.0.0.tgz#00acd20f9dbbe2f79d04697bcca2a77ee00ee031"
+  dependencies:
+    commander "~2.9.0"
+    http-proxy "~1.11.1"
+    mustache "^2.2.1"
+    shell-quote "~1.4.2"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -467,6 +536,14 @@ fs-extra@^0.30.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    klaw "^1.0.0"
 
 fs-extra@^3.0.1:
   version "3.0.1"
@@ -506,6 +583,13 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-folder-size@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-folder-size/-/get-folder-size-1.0.0.tgz#134d663a0e745611b72f71c83b13f1b12f31ba29"
+  dependencies:
+    async "^1.4.2"
+    minimist "^1.2.0"
+
 get-package-info@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/get-package-info/-/get-package-info-0.1.1.tgz#96407adc5cd6cd57f3cb6e33c029cce1b5f4ef39"
@@ -535,7 +619,7 @@ glob@^6.0.1, glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -549,6 +633,10 @@ glob@^7.0.3, glob@^7.0.5:
 graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -592,6 +680,13 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
+http-proxy@~1.11.1:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.11.3.tgz#1915dc888751e2a6bf3c2abfcb1808fa86c72353"
+  dependencies:
+    eventemitter3 "1.x.x"
+    requires-port "0.x.x"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -599,12 +694,6 @@ http-signature@~1.1.0:
     assert-plus "^0.2.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
-
-iconutil@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/iconutil/-/iconutil-1.0.2.tgz#b0e7a29a4fda6a09eb674e098418031a149caef2"
-  dependencies:
-    uuid "^2.0.1"
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -754,6 +843,10 @@ lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+lodash@^4.13.0, lodash@^4.14.0:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -845,6 +938,10 @@ ms@0.7.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+mustache@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.0.tgz#4028f7778b17708a489930a6e52ac3bca0da41d0"
 
 mv@^2.0.3:
   version "2.1.1"
@@ -1186,6 +1283,10 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+requires-port@0.x.x:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-0.0.1.tgz#4b4414411d9df7c855995dd899a8c78a2951c16d"
+
 resolve@^1.1.6:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
@@ -1204,6 +1305,10 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.6.1:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
+
+rimraf@~2.2.6:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
 rimraf@~2.4.0:
   version "2.4.5"
@@ -1236,6 +1341,15 @@ semver@~5.3.0:
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+shell-quote@~1.4.2:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.4.3.tgz#952c44e0b1ed9013ef53958179cc643e8777466b"
+  dependencies:
+    array-filter "~0.0.0"
+    array-map "~0.0.0"
+    array-reduce "~0.0.0"
+    jsonify "~0.0.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -1364,6 +1478,13 @@ tar@^2.0.0:
     fstream "^1.0.2"
     inherits "2"
 
+temp@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
+  dependencies:
+    os-tmpdir "^1.0.0"
+    rimraf "~2.2.6"
+
 throttleit@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
@@ -1423,10 +1544,6 @@ util-deprecate@1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-
 uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
@@ -1461,6 +1578,10 @@ wide-align@^1.1.0:
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
     string-width "^1.0.2"
+
+word-wrap@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"

--- a/debian/yarn.lock
+++ b/debian/yarn.lock
@@ -347,10 +347,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-electron-default-menu@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/electron-default-menu/-/electron-default-menu-1.0.1.tgz#3173c5018eb507404fec63bdf3b78c38eedba808"
-
 electron-download@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/electron-download/-/electron-download-2.2.1.tgz#3d78af3645c96435e3bf3df9b882a14cc2ca294c"


### PR DESCRIPTION
I've clean up the code for Linux, removing some redundancies and even further fixing the icon issues.
I've also added a Travis file, which is currently working only for the Linux build. It's just simply running `yarn build` to create a working Linux application and package.

You can see the output of this Travis configuration on my [build#17](https://travis-ci.org/fcastilloec/headset-electron/builds/261381397) from my fork.

I'll try to introduce OSX support for Travis in a future commit but because I have no experience with OSX, I'm not sure how successful I'll be.

Also, in a different PR, I'll try to see if Travis can publish the deb file into an APT repository based on whatever decision comes from the discussion in issue #43 