### PR TITLE
MPRIS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Headset
-![](https://travis-ci.org/headsetapp/headset-electron.svg?branch=master)
+![(https://travis-ci.org/headsetapp/headset-electron.svg?branch=master)](https://travis-ci.org/headsetapp/headset-electron)
 
 A music player for the busy ones. [http://headsetapp.co](http://headsetapp.co)
 
@@ -22,10 +22,10 @@ $ npm install
 ```bash
 electron-packager . headset \
   --ignore bin \
-  --prune true  \
-  --out build/  \
+  --prune true \
+  --out build/ \
   --overwrite  \
-  --platform=linux  \
+  --platform=linux \
   --arch=x64
 ```
 4. [Optional] For the Ubuntu build, we're using `electron-installer-debian` and for the Fedora build, we're using `electron-installer-redhat`. There might be an installer for your specifc version, just have to google for it.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Headset
-![(https://travis-ci.org/headsetapp/headset-electron.svg?branch=master)](https://travis-ci.org/headsetapp/headset-electron)
+Linux: [![Build Status](https://travis-ci.org/headsetapp/headset-electron.svg?branch=master)](https://travis-ci.org/headsetapp/headset-electron)
 
 A music player for the busy ones. [http://headsetapp.co](http://headsetapp.co)
 

--- a/linux/bin/build.sh
+++ b/linux/bin/build.sh
@@ -4,10 +4,10 @@ set -e
 
 electron-packager . headset \
   --ignore bin \
-  --prune true  \
-  --out build/  \
+  --prune true \
+  --out build/ \
   --overwrite  \
-  --platform=linux  \
+  --platform=linux \
   --arch=x64
 
 echo -e "\n\033[1mPackaging deb installer:\033[01;0m"
@@ -21,5 +21,5 @@ echo -e "\n\033[1mPackaging rpm installer:\033[01;0m"
 electron-installer-redhat \
   --src build/headset-linux-x64/ \
   --dest build/installers/ \
-  --arch amd64 \
+  --arch x86_64 \
   --config bin/config_rpm.json

--- a/linux/bin/config_deb.json
+++ b/linux/bin/config_deb.json
@@ -5,11 +5,10 @@
   "depends": [
     "dbus"
   ],
-  "section": "Sound",
+  "section": "sound",
   "categories": [
-    "GNOME",
-    "GTK",
     "Audio",
+    "AudioVideo",
     "Player",
     "Music"
   ]

--- a/linux/index.js
+++ b/linux/index.js
@@ -4,8 +4,8 @@ const { version } = require('./package')
 const path = require('path')
 const { exec } = require('child_process')
 const windowStateKeeper = require('electron-window-state');
-const DBus = require('dbus');
-const registerBindings = require('./registerBindings.js');
+const registerMediaKeys = require('./registerMediaKeys.js');
+const mprisService = require('./mprisService.js');
 
 const {
   app,
@@ -79,10 +79,8 @@ const start = () => {
     })
 
     try {
-      const bus = DBus.getBus('session');
-
-      registerBindings(win, 'gnome', bus);
-      registerBindings(win, 'mate', bus);
+      mprisService(win, player);
+      registerMediaKeys(win);
     } catch (err) {
       console.error(err);
     }

--- a/linux/mprisService.js
+++ b/linux/mprisService.js
@@ -75,31 +75,33 @@ module.exports = (win, player) => {
     mprisPlayer.volume = volume + 1e-15;
   });
 
-  mprisPlayer.on('seek', (args) => {
-    if (mprisPlayer.playbackStatus == 'Playing' ||
-        mprisPlayer.playbackStatus == 'Paused') {
-      player.webContents.send('win2Player', ['seekTo', args.position/1e6]);
-    }
-  });
-
   ipcMain.on('win2Player', (e, args) => {
-    if (args[0] == 'playVideo') {
-      mprisPlayer.playbackStatus = 'Playing';
-    } else if (args[0] == 'pauseVideo') {
-      mprisPlayer.playbackStatus = 'Paused';
-    } else if (args[0] == 'setVolume') {
-      mprisPlayer.volume = args[1]/100 + 1e-15;
-    } else if (args[0] == 'trackInfo') {
-      mprisPlayer.metadata = {
-        'xesam:artist': [ args[1]['artist'] ],
-        'xesam:title': args[1]['title'],
-        'xesam:url': "https://www.youtube.com/watch?v=" + args[1]['id'],
-        'mpris:artUrl': args[1]['thumbnail'],
-        'mpris:length': args[1]['duration'] * 1e6 //in microseconds
-      };
-    } else if (args[0] == 'seekTo') {
-      const delta = Math.round(args[1]*1e6) - mprisPlayer.position;
-      mprisPlayer.seeked(delta);
+    switch (args[0]) {
+      case 'playVideo':
+        mprisPlayer.playbackStatus = 'Playing'
+        break;
+      case 'pauseVideo':
+        mprisPlayer.playbackStatus = 'Paused'
+        break;
+      case 'setVolume':
+        mprisPlayer.volume = args[1]/100 + 1e-15
+        break;
+      case 'trackInfo':
+        mprisPlayer.canSeek = false
+        mprisPlayer.metadata = {
+          'xesam:artist': [ args[1]['artist'] ],
+          'xesam:title': args[1]['title'],
+          'xesam:url': "https://www.youtube.com/watch?v=" + args[1]['id'],
+          'mpris:artUrl': args[1]['thumbnail'],
+          'mpris:length': args[1]['duration'] * 1e6 //in microseconds
+        }
+        break;
+      case 'seekTo':
+        const delta = Math.round(args[1]*1e6) - mprisPlayer.position;
+        mprisPlayer.seeked(delta);
+        break;
+      default:
+        break;
     }
   });
 

--- a/linux/mprisService.js
+++ b/linux/mprisService.js
@@ -1,0 +1,113 @@
+const { ipcMain } = require('electron');
+const mpris = require('mpris-service');
+
+function executeMediaKey(win, key) {
+  win.webContents.executeJavaScript(`
+    window.electronConnector.emit('${key}')
+  `);
+}
+
+module.exports = (win, player) => {
+
+  const mprisPlayer = mpris({
+    name: 'headset',
+    identity: 'Headset',
+    canRaise: true,
+    supportedInterfaces: ['player'],
+    desktopEntry: 'headset',
+  });
+
+  mprisPlayer.playbackStatus = 'Stopped'
+  mprisPlayer.rate = 1+1e-15  //to avoid storing 1 as byte (nodejs dbus bug)
+  mprisPlayer.minimumRate = 1+1e-15
+  mprisPlayer.maximumRate = 1+1e-15
+  mprisPlayer.volume = 0.75
+
+  mprisPlayer.on('raise', () => {
+    win.show();
+  });
+
+  mprisPlayer.on('quit', () => {
+    exec('kill -9 $(pgrep headset) &> /dev/null')
+  });
+
+  mprisPlayer.on('rate', () => {
+    mprisPlayer.rate = 1+1e-15
+  });
+
+  mprisPlayer.on('playpause', () => {
+    if (mprisPlayer.playbackStatus == 'Playing' ||
+        mprisPlayer.playbackStatus == 'Paused') {
+      executeMediaKey(win, 'play-pause');
+    }
+  });
+
+  mprisPlayer.on('play', () => {
+    if (mprisPlayer.playbackStatus == 'Paused') {
+      executeMediaKey(win, 'play-pause');
+    }
+  });
+
+  mprisPlayer.on('pause', () => {
+    if (mprisPlayer.playbackStatus == 'Playing') {
+      executeMediaKey(win, 'play-pause');
+    }
+  });
+
+  mprisPlayer.on('next', () => {
+    if (mprisPlayer.playbackStatus == 'Playing' ||
+        mprisPlayer.playbackStatus == 'Paused') {
+          executeMediaKey(win, 'play-next');
+    }
+  });
+
+  mprisPlayer.on('previous', () => {
+    if (mprisPlayer.playbackStatus == 'Playing' ||
+        mprisPlayer.playbackStatus == 'Paused') {
+          executeMediaKey(win, 'play-previous')
+    }
+  });
+
+  mprisPlayer.on('volume', (volume) => {
+    if (volume > 1) { volume = 1 }
+    if (volume < 0) { volume = 0 }
+    player.webContents.send('win2Player', ['setVolume', volume*100]);
+    mprisPlayer.volume = volume + 1e-15;
+  });
+
+  mprisPlayer.on('seek', (args) => {
+    if (mprisPlayer.playbackStatus == 'Playing' ||
+        mprisPlayer.playbackStatus == 'Paused') {
+      player.webContents.send('win2Player', ['seekTo', args.position/1e6]);
+    }
+  });
+
+  ipcMain.on('win2Player', (e, args) => {
+    if (args[0] == 'playVideo') {
+      mprisPlayer.playbackStatus = 'Playing';
+    } else if (args[0] == 'pauseVideo') {
+      mprisPlayer.playbackStatus = 'Paused';
+    } else if (args[0] == 'setVolume') {
+      mprisPlayer.volume = args[1]/100 + 1e-15;
+    } else if (args[0] == 'trackInfo') {
+      mprisPlayer.metadata = {
+        'xesam:artist': args[1]['artist'],
+        'xesam:title': args[1]['title'],
+        'xesam:url': "https://www.youtube.com/watch?v=" + args[1]['id'],
+        'mpris:artUrl': args[1]['thumbnail'],
+        'mpris:length': args[1]['duration'] * 1e6 //in microseconds
+      };
+    } else if (args[0] == 'seekTo') {
+      const delta = Math.round(args[1]*1e6) - mprisPlayer.position;
+      mprisPlayer.seeked(delta);
+    }
+  });
+
+  ipcMain.on('player2Win', (e, args) => {
+    if (args[0] == 'currentTime') {
+      // int64 in microseconds. nodejs dbus doesn't support int64 (bug)
+      mprisPlayer.position = Math.round(args[1] * 1e6)
+    }
+  });
+
+}

--- a/linux/mprisService.js
+++ b/linux/mprisService.js
@@ -91,7 +91,7 @@ module.exports = (win, player) => {
       mprisPlayer.volume = args[1]/100 + 1e-15;
     } else if (args[0] == 'trackInfo') {
       mprisPlayer.metadata = {
-        'xesam:artist': args[1]['artist'],
+        'xesam:artist': [ args[1]['artist'] ],
         'xesam:title': args[1]['title'],
         'xesam:url': "https://www.youtube.com/watch?v=" + args[1]['id'],
         'mpris:artUrl': args[1]['thumbnail'],

--- a/linux/package.json
+++ b/linux/package.json
@@ -17,14 +17,15 @@
     "postinstall": "electron-rebuild"
   },
   "dependencies": {
-    "dbus": "^1.0.0",
-    "electron-window-state": "^4.1.1"
+    "dbus": "^0.2.23",
+    "electron-window-state": "^4.1.1",
+    "mpris-service": "^1.1.3"
   },
   "devDependencies": {
     "electron": "^1.7.5",
     "electron-installer-debian": "^0.5.2",
     "electron-installer-redhat": "^0.5.0",
-    "electron-packager": "^8.7.2",
+    "electron-packager": "^9.0.0",
     "electron-rebuild": "^1.6.0",
     "foreman": "^2.0.0"
   }

--- a/linux/registerMediaKeys.js
+++ b/linux/registerMediaKeys.js
@@ -1,10 +1,12 @@
+const DBus = require('dbus');
+
 function executeMediaKey(win, key) {
   win.webContents.executeJavaScript(`
     window.electronConnector.emit('${key}')
-  `); 
+  `);
 }
 
-module.exports = (win, desktopEnv, bus) => {
+function registerBindings(win, desktopEnv, bus) {
   const serviceName = `org.${desktopEnv}.SettingsDaemon`
   const objectPath = `/org/${desktopEnv}/SettingsDaemon/MediaKeys`
   const interfaceName = `org.${desktopEnv}.SettingsDaemon.MediaKeys`
@@ -16,20 +18,28 @@ module.exports = (win, desktopEnv, bus) => {
     }
     iface.on('MediaPlayerKeyPressed', (n, keyName) => {
       switch (keyName) {
-        case 'Next': 
-          executeMediaKey(win, 'play-next')
-          break;
-        case 'Previous': 
-          executeMediaKey(win, 'play-previous')
-          break;
-        case 'Play': 
-          executeMediaKey(win, 'play-pause')
-          break;
+        case 'Next':
+         executeMediaKey(win, 'play-next')
+         break;
+        case 'Previous':
+         executeMediaKey(win, 'play-previous')
+         break;
+        case 'Play':
+         executeMediaKey(win, 'play-pause')
+         break;
         default:
-          break;
+         return;
       }
     });
-    
+
     iface.GrabMediaPlayerKeys(0, interfaceName);
   });
-};
+}
+
+module.exports = (win) => {
+  const dbus = new DBus;
+  const bus = dbus.getBus('session');
+
+  registerBindings(win, 'gnome', bus);
+  registerBindings(win, 'mate', bus);
+}


### PR DESCRIPTION
I have tested this code on both 64 and 32 bits and it's working. I also tested it on different desktop environments and some work better than others, here's a list:

| Desktop | Status |
| --- | --- |
| Unity (Ubuntu <= 17.04) | Works |
| Cinnamon (LInux Mint) | Works |
| Elementary OS | Works |
| Budgie | Can control (No album cover) |
| KDE | Can control (seek is broken [kde bug?]) |
| Gnome Shell | Can Control (but there's no feedback or album cover) |
| Mate | Mate doesn't have mpris support |

I'm not 100% sure why some desktops only have partial support, I think it might be because they're very strict when following the `MPRIS` standard and the nodejs implementation has a big bug [issue #1](https://github.com/emersion/mpris-service/issues/1) which might affect reading metadata to display on their desktops. On the other hand, there's one player using the same `mpris-service` module that doesn't have this problem, and their implementation is almost identical to this.
There's only one bug across all desktops. When changing the volume through `MPRIS` the player doesn't show the change on the screen, even though the volume does change.
We can also implement `loopStatus` and `shuffle` but that will need some work on the player itself, so we 'll need a read/write property for it.