### PR TITLE
Return when player has not initialized

### DIFF
--- a/windows/index.js
+++ b/windows/index.js
@@ -112,6 +112,7 @@ const start = () => {
     win = null
     // after app closes in Win, the global shourtcuts are still up, disabling it here.
     globalShortcut.unregisterAll()
+    if (player === undefined) return;
     player.close()
   });
 


### PR DESCRIPTION
When I close before player is initialized, **player** object is `undefined`.
So `player.close()` will be crash the app 

![headset-electron](https://user-images.githubusercontent.com/1451365/29800448-2c40227e-8ca5-11e7-8c39-cff5f8fcc23b.gif)
