### PR TITLE
automate auto updater bump

### DIFF
--- a/auto_updater.json
+++ b/auto_updater.json
@@ -1,3 +1,3 @@
 {
-	"url": "https://github.com/headsetapp/headset-electron/releases/download/v1.6.4/Headset-1.6.3.zip"
+  "url": "https://github.com/headsetapp/headset-electron/releases/download/v1.6.4/Headset-1.6.4.zip"
 }

--- a/bin/bump_auto_updater.sh
+++ b/bin/bump_auto_updater.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "{
+  \"url\": \"https://github.com/headsetapp/headset-electron/releases/download/v$TAG_NO_V/Headset-$TAG_NO_V.zip\"
+}" > auto_updater.json

--- a/darwin/package-lock.json
+++ b/darwin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "headset",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/darwin/package.json
+++ b/darwin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "headset",
   "productName": "Headset",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Discover and collect music on YouTube",
   "license": "MIT",
   "author": "Daniel Ravina",

--- a/linux/package-lock.json
+++ b/linux/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "headset",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/linux/package.json
+++ b/linux/package.json
@@ -1,7 +1,7 @@
 {
   "name": "headset",
   "productName": "Headset",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Discover and collect music on YouTube",
   "license": "MIT",
   "author": "Daniel Ravina <hello@headsetapp.co>",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "version": "1.6.3",
+  "version": "1.6.4",
   "scripts": {
     "darwin": "cd darwin && npm install && cd ..",
     "linux": "cd linux && npm install && cd ..",
     "windows": "cd windows && npm install && cd ..",
     "lint": "eslint",
-    "version": "npm-publish-all bump --bumpType=$npm_package_version && git add ."
+    "version": "npm-publish-all bump --bumpType=$npm_package_version && git add . && npm run bump_auto_updater",
+    "bump_auto_updater": "TAG_NO_V=$npm_package_version ./bin/bump_auto_updater.sh"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.3",

--- a/windows/package-lock.json
+++ b/windows/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "headset",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/windows/package.json
+++ b/windows/package.json
@@ -1,7 +1,7 @@
 {
   "name": "headset",
   "productName": "Headset",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Discover and collect music on YouTube",
   "license": "MIT",
   "author": "Daniel Ravina",


### PR DESCRIPTION
bump to 1.6.4 and update the auto updater file on `npm run version`

Github automatically makes releases drafts when files are uploaded. So need to remember to publish a release _after_ the zip is ready. Basically this: https://github.com/headsetapp/headset-electron/wiki/Release-Cycle