### PR TITLE
Focus main window after player-window finished loading

### DIFF
--- a/darwin/index.js
+++ b/darwin/index.js
@@ -78,6 +78,7 @@ const start = () => {
 
     player.webContents.on('did-finish-load', () => {
       logger('Player window finished loading');
+      win.focus();
     });
 
     player.on('close', (e) => {

--- a/linux/index.js
+++ b/linux/index.js
@@ -82,6 +82,7 @@ const start = () => {
 
     player.webContents.on('did-finish-load', () => {
       logger('Player window finished loading');
+      win.focus();
     });
 
     player.on('close', (e) => {

--- a/windows/index.js
+++ b/windows/index.js
@@ -83,6 +83,7 @@ const start = () => {
 
     player.webContents.on('did-finish-load', () => {
       logger('Player window finished loading');
+      win.focus();
     });
 
     player.on('close', (e) => {


### PR DESCRIPTION
This is a small fix for a very annoying bug (in my opinion). 
I hated the fact that I couldn't start typing to search as soon as Headset finished opening. It's one of those tiny things that almost nobody notices, but was driving me crazy :nerd_face: 
I totally understand if this is so insignificant that doesn't deserve to be merged, this PR is mainly for my own sake :smile: