### PR TITLE
Commit version into chocoInstall script when releasing a new version

### DIFF
--- a/bin/choco_version_bump.sh
+++ b/bin/choco_version_bump.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-file='.chocolatey/headset.nuspec'
+nuspec='.chocolatey/headset.nuspec'
+install='.chocolatey/tools/chocolateyInstall.ps1'
 
-sed -i.bak "s|\(<version>\)\(.*\)\(</version>\)|\1$VERSION\3|g" $file
-rm $file.bak
+sed -i.bak "s|\(<version>\)\(.*\)\(</version>\)|\1$VERSION\3|g" $nuspec
+sed -i.bak "1s|\('\)\(.*\)\('\)|\1$VERSION\3|" $install
+
+rm $nuspec.bak
+rm $install.bak

--- a/windows/bin/build_choco.ps1
+++ b/windows/bin/build_choco.ps1
@@ -10,10 +10,7 @@ if (!(Test-Path -Path "$setup")) {
 }
 
 $sha256 = (CertUtil -hashfile "$setup" SHA256)[1].Replace(' ', '')
-
 $choco = Get-Content $chocoInstall
-
-$choco[0] = "`$version = $version"
 $choco[11] = "  checksum       = '$sha256'"
 
 $choco | Out-File -filepath "$chocoInstall" -Encoding UTF8


### PR DESCRIPTION
The file `chocolateyInstall.ps1` has a `version` variable inside that was being changed only by AppVeyor when releasing. The resulting package would have worked without problems, but our code will always show `1.7.0` as the version. This PR changes that version number when running `npm version ...` rather than inside of the AppVeyor `build_choco.ps1` script. Now all files that have a version number will show the appropriate version.