### PR TITLE
Electron 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 
-node_js: "6"
+node_js: "8"
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
     - createrepo
 
 before_install:
-- npm i -g npm@5.8.0
+- npm i -g npm@6.1.0
 
 install:
 - npm ci

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sudo yum install headset
 
 If you would like to create a build for a different environment (e.g Manjaro or Aur, etc.) please follow these steps:
 
-1. Install _NodeJs_ 6.2.0 or later
+1. Install _NodeJs_ 8 or later
 
 2. Clone the Repo
 ```bash

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ os: unstable
 clone_depth: 1
 
 environment:
-  nodejs_version: "6"
+  nodejs_version: "8"
   CERT_PASSWORD:
     secure: BOXjWrY24hdw8EhsmLkP5RVxG/aY/16gnAt//DlVIHOadhfJWHgQfh+qI7oUkgP2
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm i -g  npm@5.8.0
+  - npm i -g  npm@6.1.0
   - npm ci
   - cd windows && npm ci && cd..
 

--- a/darwin/bin/build_dist.sh
+++ b/darwin/bin/build_dist.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
+set -e
+
 echo -e '\n\033[1mPackaging dmg installer: \033[01;0m'
 mkdir -p build/installers
 zip -ryq "Headset-$NEW_VERSION.zip" build/Headset-darwin-x64/Headset.app
-create-dmg build/Headset-darwin-x64/Headset.app
 
-mv "Headset-$NEW_VERSION.dmg" build/installers/.
+set +e; create-dmg --overwrite build/Headset-darwin-x64/Headset.app; set -e
+
+mv "Headset $NEW_VERSION.dmg" build/installers/"Headset-$NEW_VERSION.dmg"
 mv "Headset-$NEW_VERSION.zip" build/installers/.

--- a/darwin/package-lock.json
+++ b/darwin/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "8.10.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.17.tgz",
-      "integrity": "sha512-3N3FRd/rA1v5glXjb90YdYUa+sOB7WrkU2rAhKZnF4TKD86Cym9swtulGuH0p9nxo7fP5woRNa8b0oFTpCO1bg==",
+      "version": "8.10.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.18.tgz",
+      "integrity": "sha512-WoepSz+wJlU5Bjq5oK6cO1oXe2FgPcjMtQPgKPS8fVaTAD0lxkScMCCbMimdkVCsykqaA4lvHWz3cmj28yimhA==",
       "dev": true
     },
     "abbrev": {
@@ -711,9 +711,9 @@
       }
     },
     "electron": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.7.tgz",
-      "integrity": "sha512-q6dn8bspX8u8z6tNU4bEas6ZrdNavnrjJ6d/oz49Nb4zFIPrdh8p29AFjFlSAavypGwAVR/PhYOAGwzZSQSSVQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.2.tgz",
+      "integrity": "sha512-XmkGVoHLOqmjZ2nU/0zEzMl3TZEz452Q1fTJFKjylg4pLYaq7na7V2uxzydVQNQukZGbERoA7ayjxXzTsXbtdA==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",

--- a/darwin/package.json
+++ b/darwin/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "create-dmg": "^3.1.0",
-    "electron": "^1.8.7",
+    "electron": "^2.0.2",
     "electron-osx-sign": "^0.4.10",
     "electron-packager": "^12.1.0",
     "foreman": "^3.0.0",

--- a/linux/bin/config_deb.json
+++ b/linux/bin/config_deb.json
@@ -20,6 +20,8 @@
   "lintianOverrides": [
     "binary-without-manpage",
     "embedded-library",
+    "hardening-no-relro",
+    "hardening-no-pie",
     "debian-changelog-file-missing"
   ]
 }

--- a/linux/package-lock.json
+++ b/linux/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "8.10.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.17.tgz",
-      "integrity": "sha512-3N3FRd/rA1v5glXjb90YdYUa+sOB7WrkU2rAhKZnF4TKD86Cym9swtulGuH0p9nxo7fP5woRNa8b0oFTpCO1bg==",
+      "version": "8.10.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.18.tgz",
+      "integrity": "sha512-WoepSz+wJlU5Bjq5oK6cO1oXe2FgPcjMtQPgKPS8fVaTAD0lxkScMCCbMimdkVCsykqaA4lvHWz3cmj28yimhA==",
       "dev": true
     },
     "abbrev": {
@@ -633,9 +633,9 @@
       }
     },
     "electron": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.7.tgz",
-      "integrity": "sha512-q6dn8bspX8u8z6tNU4bEas6ZrdNavnrjJ6d/oz49Nb4zFIPrdh8p29AFjFlSAavypGwAVR/PhYOAGwzZSQSSVQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.2.tgz",
+      "integrity": "sha512-XmkGVoHLOqmjZ2nU/0zEzMl3TZEz452Q1fTJFKjylg4pLYaq7na7V2uxzydVQNQukZGbERoA7ayjxXzTsXbtdA==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",

--- a/linux/package.json
+++ b/linux/package.json
@@ -27,7 +27,7 @@
     "mpris-service": "^1.1.3"
   },
   "devDependencies": {
-    "electron": "^1.8.7",
+    "electron": "^2.0.2",
     "electron-installer-debian": "^0.8.1",
     "electron-installer-redhat": "^0.5.0",
     "electron-packager": "^12.1.0",

--- a/windows/index.js
+++ b/windows/index.js
@@ -4,7 +4,7 @@ const { exec } = require('child_process');
 const windowStateKeeper = require('electron-window-state');
 const squirrel = require('electron-squirrel-startup');
 const debug = require('debug');
-const GhReleases = require('headset-autoupdater');
+const AutoUpdater = require('headset-autoupdater');
 const path = require('path');
 const { version } = require('./package');
 const headsetTray = require('./lib/headsetTray');
@@ -65,7 +65,7 @@ const start = () => {
     win.loadURL('https://danielravina.github.io/headset/app/');
   }
 
-  new GhReleases();
+  new AutoUpdater();
 
   win.webContents.on('did-finish-load', () => {
     logger('Main window finished loading');

--- a/windows/package-lock.json
+++ b/windows/package-lock.json
@@ -559,9 +559,9 @@
       }
     },
     "electron": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.4.tgz",
-      "integrity": "sha512-2f1cx0G3riMFODXFftF5AHXy+oHfhpntZHTDN66Hxtl09gmEr42B3piNEod9MEmw72f75LX2JfeYceqq1PF8cA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.2.tgz",
+      "integrity": "sha512-XmkGVoHLOqmjZ2nU/0zEzMl3TZEz452Q1fTJFKjylg4pLYaq7na7V2uxzydVQNQukZGbERoA7ayjxXzTsXbtdA==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",
@@ -1325,9 +1325,9 @@
       "dev": true
     },
     "home-path": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
-      "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.6.tgz",
+      "integrity": "sha512-wo+yjrdAtoXt43Vy92a+0IPCYViiyLAHyp0QVS4xL/tfvVz5sXIW1ubLZk3nhVkD92fQpUMKX+fzMjr5F489vw==",
       "dev": true
     },
     "hosted-git-info": {

--- a/windows/package.json
+++ b/windows/package.json
@@ -25,7 +25,7 @@
     "headset-autoupdater": "0.0.1"
   },
   "devDependencies": {
-    "electron": "^1.8.4",
+    "electron": "^2.0.2",
     "electron-installer-windows": "^1.1.0",
     "electron-packager": "^12.1.0",
     "foreman": "^3.0.0",


### PR DESCRIPTION
This PR not only updates electron for all OSs, but also fixes a bug that was preventing us from seeing any error when packaging for macOS on Travis.
Also, we updated to `npm@6.1.0` and the default node version is `8` now, which is a requirement for some macOS modules.