### PR TITLE
Log windows debug messages to file

### DIFF
--- a/windows/lib/headsetTray.js
+++ b/windows/lib/headsetTray.js
@@ -1,10 +1,17 @@
 const debug = require('debug');
 const { Menu } = require('electron');
+const logFile = require('electron-log');
+
+logFile.transports.file.level = true;
+logFile.transports.console.level = false;
+
+const isDebug = process.env.DEBUG.startsWith('headset');
 
 const logger = debug('headset:tray');
 
 const executeTrayCommand = (win, key) => {
   logger('Executing %o command from tray', key);
+  if (isDebug) logFile.debug('Executing %o command from tray', key);
   win.webContents.executeJavaScript(`
     window.electronConnector.emit('${key}')
   `);
@@ -12,12 +19,15 @@ const executeTrayCommand = (win, key) => {
 
 module.exports = (tray, win, player) => {
   logger('Setting tray');
+  if (isDebug) logFile.info('Setting tray');
 
   const contextMenu = Menu.buildFromTemplate([
     {
       label: 'Minimize to tray',
       click: () => {
         logger('Minimizing to tray');
+        if (isDebug) logFile.info('Minimizing to tray');
+
         win.isVisible() ? win.hide() : win.show();
         player.isVisible() ? player.hide() : player.show();
       },

--- a/windows/package-lock.json
+++ b/windows/package-lock.json
@@ -630,6 +630,11 @@
         }
       }
     },
+    "electron-log": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-2.2.16.tgz",
+      "integrity": "sha512-0zFLIJ7lMuM/HBbsHDp57RevuyMJxyfMD8KnN5z0A7gmoWJR/iqX00z/aSjQAY2OGLK7I5TpgGYhEt9crt9Z1w=="
+    },
     "electron-osx-sign": {
       "version": "0.4.10",
       "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.10.tgz",

--- a/windows/package.json
+++ b/windows/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
+    "electron-log": "^2.2.16",
     "electron-positioner": "^3.0.0",
     "electron-squirrel-startup": "^1.0.0",
     "electron-window-state": "^4.1.1",


### PR DESCRIPTION
Logging to the terminal doesn't seem to work with any version of electron for windows.
This will allow us to log into a file to check for errors.