### PR TITLE
Update dbus-native (and other minor modules)

### DIFF
--- a/darwin/package-lock.json
+++ b/darwin/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "8.10.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.37.tgz",
-      "integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig==",
+      "version": "8.10.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.38.tgz",
+      "integrity": "sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==",
       "dev": true
     },
     "abbrev": {
@@ -631,11 +631,6 @@
         }
       }
     },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -705,9 +700,9 @@
       }
     },
     "electron": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-3.0.7.tgz",
-      "integrity": "sha512-c/pww23/oPm3wt/wPshuAQCH4ooysS29a9fahxpvYP3ghFZ0zFHN3BWR/WHIEIqPGXWMTD4XbsD7lUtRZEZB+g==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-3.0.10.tgz",
+      "integrity": "sha512-I39IeQP3NOlbjKzTDK8uK2JdiHDfhV5SruCS2Gttkn2MaKCY+yIzQ6Wr4DyBXLeTEkL1sbZxbqQVhCavAliv5w==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",
@@ -954,11 +949,10 @@
       }
     },
     "electron-window-state": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.2.tgz",
-      "integrity": "sha512-fcSS+ZxfY8K14Ig7XI0/PHZ54wBr1LEPEgMTRlFn799xDQJ9UsP8Ti+NNb7JhvRaJBsL7MWvtY6vWBk4BpVfMw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.3.tgz",
+      "integrity": "sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==",
       "requires": {
-        "deep-equal": "^1.0.1",
         "jsonfile": "^4.0.0",
         "mkdirp": "^0.5.1"
       },
@@ -1530,9 +1524,9 @@
       }
     },
     "i18next": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-12.0.0.tgz",
-      "integrity": "sha512-Zy/nFpmBZxgmi6k9HkHbf+MwvAwiY5BDzNjNfvyLPKyalc2YBwwZtblESDlTKLDO8XSv23qYRY2uZcADDlRSjQ=="
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-12.1.0.tgz",
+      "integrity": "sha512-AexmwGkKxwKfo5fGeXTWEY4xqzRPigQ1S/0InOUUVziGO54cd4fKyYK8ED1Thx9fd+WA3fRSZ+1iekvFQMbsFw=="
     },
     "i18next-node-remote-backend": {
       "version": "1.0.0",

--- a/darwin/package.json
+++ b/darwin/package.json
@@ -20,14 +20,14 @@
   "dependencies": {
     "debug": "^4.1.0",
     "electron-default-menu": "^1.0.1",
-    "electron-window-state": "^5.0.2",
+    "electron-window-state": "^5.0.3",
     "headset-autoupdater": "0.0.1",
-    "i18next": "^12.0.0",
+    "i18next": "^12.1.0",
     "i18next-node-remote-backend": "^1.0.0"
   },
   "devDependencies": {
     "create-dmg": "^3.2.0",
-    "electron": "^3.0.7",
+    "electron": "^3.0.10",
     "electron-osx-sign": "^0.4.11",
     "electron-packager": "^12.2.0",
     "foreman": "^3.0.1",

--- a/linux/package-lock.json
+++ b/linux/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "8.10.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.37.tgz",
-      "integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig==",
+      "version": "8.10.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.38.tgz",
+      "integrity": "sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A==",
       "dev": true
     },
     "abbrev": {
@@ -231,9 +231,9 @@
       }
     },
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
       "optional": true
     },
     "block-stream": {
@@ -583,18 +583,18 @@
       }
     },
     "dbus-native": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.2.5.tgz",
-      "integrity": "sha512-ocxMKCV7QdiNhzhFSeEMhj258OGtvpANSb3oWGiotmI5h1ZIse0TMPcSLiXSpqvbYvQz2Y5RsYPMNYLWhg9eBw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.4.0.tgz",
+      "integrity": "sha512-i3zvY3tdPEOaMgmK4riwupjDYRJ53rcE1Kj8rAgnLOFmBd0DekUih59qv8v+Oyils/U9p+s4sSsaBzHWLztI+Q==",
       "requires": {
         "abstract-socket": "^2.0.0",
-        "event-stream": "^3.1.7",
+        "event-stream": "^4.0.0",
         "hexy": "^0.2.10",
-        "long": "^3.0.1",
+        "long": "^4.0.0",
         "optimist": "^0.6.1",
         "put": "0.0.6",
         "safe-buffer": "^5.1.1",
-        "xml2js": "0.1.14"
+        "xml2js": "^0.4.17"
       }
     },
     "debug": {
@@ -632,11 +632,6 @@
         "readable-stream": "^1.1.8",
         "touch": "0.0.3"
       }
-    },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -698,9 +693,9 @@
       }
     },
     "electron": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-3.0.7.tgz",
-      "integrity": "sha512-c/pww23/oPm3wt/wPshuAQCH4ooysS29a9fahxpvYP3ghFZ0zFHN3BWR/WHIEIqPGXWMTD4XbsD7lUtRZEZB+g==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-3.0.10.tgz",
+      "integrity": "sha512-I39IeQP3NOlbjKzTDK8uK2JdiHDfhV5SruCS2Gttkn2MaKCY+yIzQ6Wr4DyBXLeTEkL1sbZxbqQVhCavAliv5w==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",
@@ -1233,11 +1228,10 @@
       }
     },
     "electron-window-state": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.2.tgz",
-      "integrity": "sha512-fcSS+ZxfY8K14Ig7XI0/PHZ54wBr1LEPEgMTRlFn799xDQJ9UsP8Ti+NNb7JhvRaJBsL7MWvtY6vWBk4BpVfMw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.3.tgz",
+      "integrity": "sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==",
       "requires": {
-        "deep-equal": "^1.0.1",
         "jsonfile": "^4.0.0",
         "mkdirp": "^0.5.1"
       },
@@ -1274,12 +1268,11 @@
       "dev": true
     },
     "event-stream": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
       "requires": {
         "duplexer": "^0.1.1",
-        "flatmap-stream": "^0.1.0",
         "from": "^0.1.7",
         "map-stream": "0.0.7",
         "pause-stream": "^0.0.11",
@@ -1389,11 +1382,6 @@
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
-    },
-    "flatmap-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-      "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw=="
     },
     "flora-colossus": {
       "version": "1.0.0",
@@ -2147,9 +2135,9 @@
       }
     },
     "long": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -3505,18 +3493,18 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.14.tgz",
-      "integrity": "sha1-UnTmf1pkxfkpdM2FE54DMq3GuQw=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": ">=0.1.1"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmldom": {
       "version": "0.1.27",

--- a/linux/package.json
+++ b/linux/package.json
@@ -20,13 +20,13 @@
     "repo": "NEW_VERSION=$npm_package_version ./bin/linux_repo.sh"
   },
   "dependencies": {
-    "dbus-native": "^0.2.5",
+    "dbus-native": "^0.4.0",
     "debug": "^4.1.0",
-    "electron-window-state": "^5.0.2",
+    "electron-window-state": "^5.0.3",
     "mpris-service": "^1.1.4"
   },
   "devDependencies": {
-    "electron": "^3.0.7",
+    "electron": "^3.0.10",
     "electron-installer-debian": "^1.0.0",
     "electron-installer-redhat": "^0.5.0",
     "electron-packager": "^12.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,21 +24,21 @@
       }
     },
     "acorn": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.3.tgz",
-      "integrity": "sha512-xEnlTS2J0PKuub0pd2Y4W58iEo1sfRZ3h23E8AKmlnV8Nc6E/syRdVeo0DMuLSrgRJZHnFeDou2llXfB+wb1/A==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
-      "integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
     },
     "ajv": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-      "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -163,27 +163,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
@@ -378,7 +357,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -785,21 +764,6 @@
         "object-keys": "^1.0.12"
       }
     },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -959,9 +923,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.8.0.tgz",
-      "integrity": "sha512-Zok6Bru3y2JprqTNm14mgQ15YQu/SMDkWdnmHfFg770DIUlmMFd/gqqzCHekxzjHZJxXv3tmTpH0C1icaYJsRQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.9.0.tgz",
+      "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1303,14 +1267,14 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
     },
@@ -1410,24 +1374,10 @@
       }
     },
     "globals": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-      "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
       "dev": true
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
     },
     "globule": {
       "version": "1.2.1",
@@ -1670,30 +1620,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
     },
     "is-promise": {
       "version": "2.1.0",
@@ -2631,7 +2557,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:windows": "mocha test/*.js"
   },
   "devDependencies": {
-    "eslint": "^5.8.0",
+    "eslint": "^5.9.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-promise": "^4.0.1",

--- a/windows/package-lock.json
+++ b/windows/package-lock.json
@@ -499,11 +499,6 @@
         }
       }
     },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -553,9 +548,9 @@
       }
     },
     "electron": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-3.0.7.tgz",
-      "integrity": "sha512-c/pww23/oPm3wt/wPshuAQCH4ooysS29a9fahxpvYP3ghFZ0zFHN3BWR/WHIEIqPGXWMTD4XbsD7lUtRZEZB+g==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-3.0.10.tgz",
+      "integrity": "sha512-I39IeQP3NOlbjKzTDK8uK2JdiHDfhV5SruCS2Gttkn2MaKCY+yIzQ6Wr4DyBXLeTEkL1sbZxbqQVhCavAliv5w==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",
@@ -890,11 +885,10 @@
       }
     },
     "electron-window-state": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.2.tgz",
-      "integrity": "sha512-fcSS+ZxfY8K14Ig7XI0/PHZ54wBr1LEPEgMTRlFn799xDQJ9UsP8Ti+NNb7JhvRaJBsL7MWvtY6vWBk4BpVfMw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.3.tgz",
+      "integrity": "sha512-1mNTwCfkolXl3kMf50yW3vE2lZj0y92P/HYWFBrb+v2S/pCka5mdwN3cagKm458A7NjndSwijynXgcLWRodsVg==",
       "requires": {
-        "deep-equal": "^1.0.1",
         "jsonfile": "^4.0.0",
         "mkdirp": "^0.5.1"
       },
@@ -1410,9 +1404,9 @@
       }
     },
     "i18next": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-12.0.0.tgz",
-      "integrity": "sha512-Zy/nFpmBZxgmi6k9HkHbf+MwvAwiY5BDzNjNfvyLPKyalc2YBwwZtblESDlTKLDO8XSv23qYRY2uZcADDlRSjQ=="
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-12.1.0.tgz",
+      "integrity": "sha512-AexmwGkKxwKfo5fGeXTWEY4xqzRPigQ1S/0InOUUVziGO54cd4fKyYK8ED1Thx9fd+WA3fRSZ+1iekvFQMbsFw=="
     },
     "i18next-node-remote-backend": {
       "version": "1.0.0",

--- a/windows/package.json
+++ b/windows/package.json
@@ -21,13 +21,13 @@
     "debug": "^4.1.0",
     "electron-log": "^2.2.17",
     "electron-squirrel-startup": "^1.0.0",
-    "electron-window-state": "^5.0.2",
+    "electron-window-state": "^5.0.3",
     "headset-autoupdater": "0.0.1",
-    "i18next": "^12.0.0",
+    "i18next": "^12.1.0",
     "i18next-node-remote-backend": "^1.0.0"
   },
   "devDependencies": {
-    "electron": "^3.0.7",
+    "electron": "^3.0.10",
     "electron-installer-windows": "^1.1.0",
     "electron-packager": "^12.2.0",
     "foreman": "^3.0.1",


### PR DESCRIPTION
This PR will solve the failing Linux build on Travis due to malware found in one of the dependencies of `dbus-native`
I contacted the developer of `dbus-native` and a new version was released.