### PR TITLE
Fix media keys on osx

### DIFF
--- a/darwin/index.js
+++ b/darwin/index.js
@@ -98,21 +98,21 @@ const start = () => {
     `);
 
     logger('Registering MediaKeys');
-    globalShortcut.register('MediaPlayPause', () => {
+    globalShortcut.register('mediaplaypause', () => {
       logger('Executing %o media key command', 'play-pause');
       win.webContents.executeJavaScript(`
         window.electronConnector.emit('play-pause')
       `);
     });
 
-    globalShortcut.register('MediaNextTrack', () => {
+    globalShortcut.register('medianexttrack', () => {
       logger('Executing %o media key command', 'play-next');
       win.webContents.executeJavaScript(`
         window.electronConnector.emit('play-next')
       `);
     });
 
-    globalShortcut.register('MediaPreviousTrack', () => {
+    globalShortcut.register('mediaprevioustrack', () => {
       logger('Executing %o media key command', 'play-previous');
       win.webContents.executeJavaScript(`
         window.electronConnector.emit('play-previous')


### PR DESCRIPTION
Hi, nice work with this package.
I was running it on osx and I found that the media keys weren't working, at least for me, using macOS Mojave. So, I searched and found the solution. Renaming the names of the media keys solved the problem for me, so I'm sending this patch to fix it.
I don't have a windows machine here, but the windows build could have the same problem. I'm not changing the windows js because I can't test it.  

thanks for your time