### PR TITLE
New mpris

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
     "plugin:promise/recommended"
   ],
   "parserOptions": {
-    "ecmaVersion": 2016,
+    "ecmaVersion": 2018,
     "sourceType": "module"
   },
   "globals": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,7 @@
     "no-console": "off",
     "func-names": "off",
     "class-methods-use-this": "off",
+    "no-bitwise": ["error", {"allow": ["~"]} ],
     "no-unused-expressions": ["error", {"allowTernary": true}],
     "prefer-destructuring": ["error", {"array": false}]
   }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,6 @@ We welcome many ways of contributing to Headset:
 
     which will install both global and OS-dependent packages.
 
-    Linux users also need to install appropriate dependencies for [dbus](https://www.npmjs.com/package/dbus#general)
-
 
 4. Now you can run the app:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ $ git clone https://github.com/headsetapp/headset-electron.git
 $ cd headset-electron/linux
 $ npm install
 ```
-On Linux, the `dbus` module also has it's own [dependencies](https://github.com/Shouqun/node-dbus#dependencies) that need to be installed.
 
 4. Create your build:
 ```bash
@@ -85,6 +84,5 @@ electron-packager . \
   --platform=linux \
   --arch=x64
 ```
-For Linux, a 32bit system is required in order to package Headset for `arch=ia32` due to `dbus` module own dependencies.
 
 5. [Optional] For the Ubuntu build, we're using `electron-installer-debian` and for the Fedora build, we're using `electron-installer-redhat`. There might be an installer for your specific version, just have to google it.

--- a/linux/lib/mprisService.js
+++ b/linux/lib/mprisService.js
@@ -26,9 +26,11 @@ module.exports = (win, player, app) => {
   });
 
   mprisPlayer.playbackStatus = 'Stopped';
-  mprisPlayer.rate = 1 + 1e-15; // to avoid storing 1 as byte (nodejs dbus bug)
-  mprisPlayer.minimumRate = 1 + 1e-15;
-  mprisPlayer.maximumRate = 1 + 1e-15;
+  mprisPlayer.rate = 1;
+  mprisPlayer.canSeek = true;
+  mprisPlayer.canControl = true;
+  mprisPlayer.minimumRate = 1;
+  mprisPlayer.maximumRate = 1;
   mprisPlayer.volume = 0.75;
 
   mprisPlayer.on('raise', () => {
@@ -42,8 +44,8 @@ module.exports = (win, player, app) => {
   });
 
   mprisPlayer.on('rate', () => {
-    logger('Changing rate');
-    mprisPlayer.rate = 1 + 1e-15;
+    logger('Attempting to change rate');
+    mprisPlayer.rate = 1;
   });
 
   mprisPlayer.on('playpause', () => {
@@ -86,8 +88,8 @@ module.exports = (win, player, app) => {
 
   mprisPlayer.on('volume', (volume) => {
     if (mprisPlayer.playbackStatus !== 'Stopped') {
-      if (volume >= 1) { volume = 1 - 1e-15; }
-      if (volume <= 0) { volume = 1e-15; }
+      if (volume > 1) { volume = 1; }
+      if (volume < 0) { volume = 0; }
 
       logger('Volume received, set to: %d', volume);
       changeVolumeState(win, volume * 100);
@@ -96,27 +98,68 @@ module.exports = (win, player, app) => {
     }
   });
 
+  mprisPlayer.on('seek', (seek) => {
+    if (mprisPlayer.playbackStatus !== 'Stopped') {
+      if (seek < 0) seek = ~seek;
+      logger(`Seek ${seek / 1e6} sec`);
+      win.webContents.send('player2Win', ['seekTo', (mprisPlayer.getPosition() + seek) / 1e6]); // in seconds
+    }
+  });
+
+  mprisPlayer.on('position', (arg) => {
+    if (mprisPlayer.playbackStatus !== 'Stopped') {
+      logger(`Go to position ${arg.position / 1e6} sec`);
+      win.webContents.send('player2Win', ['seekTo', arg.position / 1e6]); // in seconds
+    }
+  });
+
+  mprisPlayer.on('shuffle', (shuffle) => {
+    if (mprisPlayer.playbackStatus !== 'Stopped') {
+      logger(`Set shuffling: ${shuffle}`);
+      win.webContents.send('player2Win', ['setShuffle', shuffle]);
+      mprisPlayer.shuffle = shuffle;
+    }
+  });
+
+  mprisPlayer.on('loopStatus', (loop) => {
+    if (mprisPlayer.playbackStatus !== 'Stopped') {
+      logger(`Set looping to: ${loop}`);
+      mprisPlayer.loopStatus = loop;
+      let repeat = null;
+      if (loop === 'Track') repeat = 'one';
+      if (loop === 'Playlist') repeat = 'all';
+      if (loop === 'None') repeat = null;
+      win.webContents.send('player2Win', ['onRepeat', repeat]);
+    }
+  });
+
   ipcMain.on('win2Player', (e, args) => {
     switch (args[0]) {
       case 'setVolume':
-        mprisPlayer.volume = (args[1] / 100) + 1e-15;
+        mprisPlayer.volume = (args[1] / 100);
         break;
       case 'trackInfo':
-        mprisPlayer.canSeek = false;
         mprisPlayer.metadata = {
           'xesam:artist': [args[1].artist],
           'xesam:title': args[1].title,
           'xesam:url': `https://www.youtube.com/watch?v=${args[1].id}`,
+          'mpris:trackid': mprisPlayer.objectPath('track/0'),
           'mpris:artUrl': args[1].thumbnail,
           'mpris:length': args[1].duration * 1e6, // in microseconds
         };
         logger(['Track Info:', mprisPlayer.metadata]);
         break;
-      case 'seekTo': {
-        const delta = Math.round(args[1] * 1e6) - mprisPlayer.position;
-        mprisPlayer.seeked(delta);
+      case 'seekTo':
+        mprisPlayer.seeked(Math.round(args[1] * 1e6)); // in microseconds
         break;
-      }
+      case 'shuffle':
+        mprisPlayer.shuffle = args[1];
+        break;
+      case 'repeat':
+        if (args[1] === 'one') mprisPlayer.loopStatus = 'Track';
+        if (args[1] === 'all') mprisPlayer.loopStatus = 'Playlist';
+        if (args[1] === null) mprisPlayer.loopStatus = 'None';
+        break;
       default:
     }
   });
@@ -124,8 +167,7 @@ module.exports = (win, player, app) => {
   ipcMain.on('player2Win', (e, args) => {
     switch (args[0]) {
       case 'currentTime':
-        // int64 in microseconds. nodejs dbus doesn't support int64 (bug)
-        mprisPlayer.position = Math.round(args[1] * 1e6);
+        mprisPlayer.getPosition = () => Math.round(args[1] * 1e6); // in microseconds
         break;
       case 'onStateChange':
         if (args[1] === 1) mprisPlayer.playbackStatus = 'Playing';

--- a/linux/lib/registerMediaKeys.js
+++ b/linux/lib/registerMediaKeys.js
@@ -34,7 +34,7 @@ async function registerBindings(win, desktopEnv, bus) {
     const settings = await bus.getProxyObject(serviceName, objectPath);
     const mediaKeys = settings.getInterface(interfaceName);
 
-    mediaKeys.on('MediaPlayerKeyPressed', (iface, n, keyName) => {
+    mediaKeys.on('MediaPlayerKeyPressed', (iface, keyName) => {
       logger('Media key pressed: %o', keyName);
       switch (keyName) {
         case 'Next':

--- a/linux/lib/registerMediaKeys.js
+++ b/linux/lib/registerMediaKeys.js
@@ -1,4 +1,4 @@
-const DBus = require('dbus-native');
+const DBus = require('dbus-next');
 const debug = require('debug');
 const { ipcMain } = require('electron');
 
@@ -19,7 +19,7 @@ function executeMediaKey(win, key) {
   `);
 }
 
-function registerBindings(win, desktopEnv, bus) {
+async function registerBindings(win, desktopEnv, bus) {
   let serviceName = `org.${desktopEnv}.SettingsDaemon`;
   let objectPath = `/org/${desktopEnv}/SettingsDaemon/MediaKeys`;
   let interfaceName = `org.${desktopEnv}.SettingsDaemon.MediaKeys`;
@@ -30,11 +30,11 @@ function registerBindings(win, desktopEnv, bus) {
     interfaceName = 'org.gnome.SettingsDaemon.MediaKeys';
   }
 
-  bus.getService(serviceName).getInterface(objectPath, interfaceName, (err, iface) => {
-    // Error when gnome|gnome3|mate is not found
-    if (err) return;
+  try {
+    const settings = await bus.getProxyObject(serviceName, objectPath);
+    const mediaKeys = settings.getInterface(interfaceName);
 
-    iface.on('MediaPlayerKeyPressed', (n, keyName) => {
+    mediaKeys.on('MediaPlayerKeyPressed', (iface, n, keyName) => {
       logger('Media key pressed: %o', keyName);
       switch (keyName) {
         case 'Next':
@@ -44,16 +44,17 @@ function registerBindings(win, desktopEnv, bus) {
           executeMediaKey(win, 'play-previous');
           break;
         case 'Play':
-          if (track !== null) {
-            executeMediaKey(win, 'play-pause');
-          }
+          if (track !== null) executeMediaKey(win, 'play-pause');
           break;
         default:
       }
     });
-    iface.GrabMediaPlayerKeys('headset', 0);
+
+    mediaKeys.GrabMediaPlayerKeys('headset', 0);
     logger('Grabbed media keys for %o', desktopEnv);
-  });
+  } catch (err) {
+    // Error if trying to grab keys in another desktop environment
+  }
 }
 
 module.exports = (win) => {

--- a/linux/package-lock.json
+++ b/linux/package-lock.json
@@ -449,21 +449,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "dbus-native": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.4.0.tgz",
-      "integrity": "sha512-i3zvY3tdPEOaMgmK4riwupjDYRJ53rcE1Kj8rAgnLOFmBd0DekUih59qv8v+Oyils/U9p+s4sSsaBzHWLztI+Q==",
-      "requires": {
-        "abstract-socket": "^2.0.0",
-        "event-stream": "^4.0.0",
-        "hexy": "^0.2.10",
-        "long": "^4.0.0",
-        "optimist": "^0.6.1",
-        "put": "0.0.6",
-        "safe-buffer": "^5.1.1",
-        "xml2js": "^0.4.17"
-      }
-    },
     "dbus-next": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/dbus-next/-/dbus-next-0.3.1.tgz",
@@ -907,20 +892,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "event-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-      "requires": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
       }
     },
     "eventemitter3": {
@@ -1665,11 +1636,6 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -1704,11 +1670,6 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
-    },
-    "map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
     },
     "mem": {
       "version": "4.1.0",
@@ -1935,6 +1896,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -2473,14 +2435,6 @@
       "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
       "dev": true
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "requires": {
-        "through": "2"
-      }
-    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -2496,15 +2450,6 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
-      }
-    },
-    "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
       }
     },
     "string-width": {
@@ -2784,7 +2729,8 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/linux/package-lock.json
+++ b/linux/package-lock.json
@@ -33,12 +33,6 @@
       "integrity": "sha512-e9wgeY6gaY21on3ve0xAjgBVjGDWq/xUteK0ujsE53bUoxycMkqfnkUgMt6ffZtykZ5X12Mg3T7Pw4TRCObDKg==",
       "dev": true
     },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
     "abstract-socket": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abstract-socket/-/abstract-socket-2.0.0.tgz",
@@ -66,63 +60,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "dev": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
     },
     "array-filter": {
       "version": "0.0.1",
@@ -264,15 +201,6 @@
       "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
       "optional": true
     },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
-      "requires": {
-        "inherits": "~2.0.0"
-      }
-    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -314,8 +242,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "camelcase": {
       "version": "2.1.1",
@@ -339,36 +266,10 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
     "chromium-pickle-js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
       "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^2.0.0"
-      }
-    },
-    "cli-spinners": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-      "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
       "dev": true
     },
     "cliui": {
@@ -415,37 +316,10 @@
         }
       }
     },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "dev": true
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
     },
     "combined-stream": {
@@ -519,12 +393,6 @@
         }
       }
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -581,14 +449,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "dbus": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dbus/-/dbus-1.0.3.tgz",
-      "integrity": "sha1-vO2hSGc7wvzKIEK6BqlZZXYmibw=",
-      "requires": {
-        "nan": "^2.1.0"
-      }
-    },
     "dbus-native": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.4.0.tgz",
@@ -602,6 +462,57 @@
         "put": "0.0.6",
         "safe-buffer": "^5.1.1",
         "xml2js": "^0.4.17"
+      }
+    },
+    "dbus-next": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/dbus-next/-/dbus-next-0.3.1.tgz",
+      "integrity": "sha512-tTmAZmXrGtJpEaZ3EZUoxPSAZAaofZYhyVcxk2o9/g+KQOYNlEC8lMvLFFAgBn/kXOveLViZWEB0OUP2hR69Yg==",
+      "requires": {
+        "abstract-socket": "^2.0.0",
+        "event-stream": "3.3.4",
+        "hexy": "^0.2.10",
+        "jsbi": "^2.0.5",
+        "put": "0.0.6",
+        "safe-buffer": "^5.1.1",
+        "xml2js": "^0.4.17"
+      },
+      "dependencies": {
+        "event-stream": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+          "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+          "requires": {
+            "duplexer": "~0.1.1",
+            "from": "~0",
+            "map-stream": "~0.1.0",
+            "pause-stream": "0.0.11",
+            "split": "0.3",
+            "stream-combiner": "~0.0.4",
+            "through": "~2.3.1"
+          }
+        },
+        "map-stream": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+          "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+        },
+        "split": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+          "requires": {
+            "through": "2"
+          }
+        },
+        "stream-combiner": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+          "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+          "requires": {
+            "duplexer": "~0.1.1"
+          }
+        }
       }
     },
     "debug": {
@@ -631,31 +542,10 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true,
-      "requires": {
-        "clone": "^1.0.2"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true
     },
     "duplexer": {
@@ -976,36 +866,6 @@
         "rimraf": "^2.6.2"
       }
     },
-    "electron-rebuild": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.8.4.tgz",
-      "integrity": "sha512-QBUZg1due+R0bww5rNd4gEcsKczyhxyLrxSFZlKihwHRxaiHrGut532JAUe0fRz+VIU4WNSfNKyZ/ZwSGjaDhA==",
-      "dev": true,
-      "requires": {
-        "colors": "^1.3.3",
-        "debug": "^4.1.1",
-        "detect-libc": "^1.0.3",
-        "fs-extra": "^7.0.1",
-        "node-abi": "^2.7.0",
-        "node-gyp": "^3.8.0",
-        "ora": "^3.0.0",
-        "spawn-rx": "^3.0.0",
-        "yargs": "^12.0.5"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        }
-      }
-    },
     "electron-window-state": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.3.tgz",
@@ -1048,12 +908,6 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
     },
     "event-stream": {
       "version": "4.0.1",
@@ -1305,18 +1159,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
-    },
     "galactus": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/galactus/-/galactus-0.2.1.tgz",
@@ -1350,22 +1192,6 @@
       "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
       "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==",
       "dev": true
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -1565,18 +1391,6 @@
         "har-schema": "^2.0.0"
       }
     },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -1751,6 +1565,11 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "jsbi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-2.0.5.tgz",
+      "integrity": "sha512-TzO/62Hxeb26QMb4IGlI/5X+QLr9Uqp1FPkwp2+KOICW+Q+vSuFj61c8pkT6wAns4WcK56X7CmSHhJeDGWOqxQ=="
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -1840,26 +1659,11 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
-    },
-    "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.1"
-      }
     },
     "long": {
       "version": "4.0.0",
@@ -1993,11 +1797,12 @@
       }
     },
     "mpris-service": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/mpris-service/-/mpris-service-1.1.4.tgz",
-      "integrity": "sha512-meB5rDpfeg0H0/ddMFUvoCuVPyNIiRQtlmc3HPlxgPiuiYLtnmWM4eLgsZ71mRqeLK/sh4ylN4YdWrDz+9dabg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mpris-service/-/mpris-service-2.0.0.tgz",
+      "integrity": "sha512-qlAOD1GJ0BJvfijNcpdJODPy4Iu1aKh0dt9mnfZpAp8KnfHDIjcUv4/TAYF0m9gucsgVMeK5OeMnaY+miuy+6Q==",
       "requires": {
-        "dbus": "^1.0.3"
+        "dbus-next": "0.3.1",
+        "source-map-support": "^0.5.9"
       }
     },
     "ms": {
@@ -2015,50 +1820,14 @@
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "optional": true
     },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-abi": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
-      "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
-      "dev": true,
-      "requires": {
-        "semver": "^5.4.1"
-      }
-    },
-    "node-gyp": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-      "dev": true,
-      "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        }
-      }
     },
     "nodeify": {
       "version": "1.0.1",
@@ -2068,15 +1837,6 @@
       "requires": {
         "is-promise": "~1.0.0",
         "promise": "~1.3.0"
-      }
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -2098,18 +1858,6 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
       }
     },
     "nugget": {
@@ -2177,15 +1925,6 @@
         "wrappy": "1"
       }
     },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^1.0.0"
-      }
-    },
     "opener": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
@@ -2200,43 +1939,6 @@
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
       }
-    },
-    "ora": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-3.1.0.tgz",
-      "integrity": "sha512-vRBPaNCclUi8pUxRF/G8+5qEQkc6EgzKK1G2ZNJUIGu088Un5qIxFXeDgymvPRM9nmrcUOGzQgS1Vmtz+NtlMw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^1.3.1",
-        "log-symbols": "^2.2.0",
-        "strip-ansi": "^5.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.0.0"
-          }
-        }
-      }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
     },
     "os-locale": {
       "version": "3.1.0",
@@ -2254,16 +1956,6 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
     },
     "p-defer": {
       "version": "1.0.0",
@@ -2641,16 +2333,6 @@
         "path-parse": "^1.0.6"
       }
     },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -2658,15 +2340,6 @@
       "dev": true,
       "requires": {
         "glob": "^7.0.5"
-      }
-    },
-    "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -2748,26 +2421,18 @@
         "string-width": "^1.0.1"
       }
     },
-    "spawn-rx": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-3.0.0.tgz",
-      "integrity": "sha512-dw4Ryg/KMNfkKa5ezAR5aZe9wNwPdKlnHEXtHOjVnyEDSPQyOpIPPRtcIiu7127SmtHhaCjw21yC43HliW0iIg==",
-      "dev": true,
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
       "requires": {
-        "debug": "^2.5.1",
-        "lodash.assign": "^4.2.0",
-        "rxjs": "^6.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "spdx-correct": {
@@ -2918,26 +2583,6 @@
         }
       }
     },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
-    "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true,
-      "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
-      }
-    },
     "throttleit": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
@@ -3016,12 +2661,6 @@
       "requires": {
         "utf8-byte-length": "^1.0.1"
       }
-    },
-    "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -3121,15 +2760,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-      "dev": true,
-      "requires": {
-        "defaults": "^1.0.3"
-      }
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -3144,15 +2774,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/linux/package.json
+++ b/linux/package.json
@@ -19,7 +19,7 @@
     "repo": "NEW_VERSION=$npm_package_version ./bin/linux_repo.sh"
   },
   "dependencies": {
-    "dbus-native": "^0.4.0",
+    "dbus-next": "^0.3.1",
     "debug": "^4.1.1",
     "electron-window-state": "^5.0.3",
     "mpris-service": "^2.0.0"

--- a/linux/package.json
+++ b/linux/package.json
@@ -16,14 +16,13 @@
     "pack": "NODE_ENV=production ./bin/build_package.sh",
     "dist": "NODE_ENV=production ./bin/build_installer.sh",
     "build": "npm run pack && npm run dist",
-    "postinstall": "electron-rebuild",
     "repo": "NEW_VERSION=$npm_package_version ./bin/linux_repo.sh"
   },
   "dependencies": {
     "dbus-native": "^0.4.0",
     "debug": "^4.1.1",
     "electron-window-state": "^5.0.3",
-    "mpris-service": "^1.1.4"
+    "mpris-service": "^2.0.0"
   },
   "devDependencies": {
     "electron": "^4.0.6",
@@ -31,7 +30,6 @@
     "electron-installer-redhat": "^1.0.1",
     "electron-packager": "^13.1.0",
     "electron-packager-languages": "^0.3.0",
-    "electron-rebuild": "^1.8.4",
     "foreman": "^3.0.1",
     "http-server": "^0.11.1"
   }


### PR DESCRIPTION
This will update MPRIS to the new version which uses the new `dbus-next` module. Now we can use the same module for registering media keys.
The new module doesn't need the dbus dependencies for Linux making easier to build. We can now even build a 32bit version from a 64bit machine.
It also fixes my workaround for some properties of MPRIS where I had to add `1e-15`