### PR TITLE
ci: use ubuntu-18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build and test
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-18.04', 'macos-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     outputs:
       current_tag: ${{ steps.tags.outputs.newtag }}
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Install Dependencies (Linux)
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-18.04'
       run: sudo apt-get install fakeroot dpkg rpm lintian gnupg2 xvfb
     - name: Install Dependencies (macOS)
       if: matrix.os == 'macos-latest'
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Get tags
       id: tags
-      if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest'
+      if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-18.04'
       run: |
         git fetch --tags -f
         ./bin/getTags.sh
@@ -48,7 +48,7 @@ jobs:
       run: npm run lint
 
     - name: Building (Linux)
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-18.04'
       run: npm run build:linux
     - name: Building (macOS)
       if: matrix.os == 'macos-latest'
@@ -66,7 +66,7 @@ jobs:
       with:
         run: npm run test:app
     - name: Test Linux installers
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-18.04'
       run: npm run test:linux
 
     - name: Upload artifacts
@@ -79,7 +79,7 @@ jobs:
   publish:
     name: Publish to Github Releases
     needs: build
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
@@ -106,7 +106,7 @@ jobs:
   linux_repo:
     name: Publish Linux repositories
     needs: build
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-18.04'
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
@@ -118,7 +118,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v2
       with:
-        name: installers-ubuntu-latest
+        name: installers-ubuntu-18.04
         path: build/installers/
     - name: Creating repositories
       run: |


### PR DESCRIPTION
Ubuntu 20.04 (which is now used by GitHub Actions) has removed the package createrepo, which is needed to build the rpm repository