### PR TITLE
ci: sign RedHat installer for GitHub release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
       run: npm run build:windows
       env:
         CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+    - name: Signing RedHat installer
+      if: matrix.os == 'ubuntu-18.04' && startsWith(github.ref, 'refs/tags/')
+      run: |
+        gpg --quiet --batch --yes --decrypt --passphrase=${{ secrets.LINUX_CERT_PASSWORD }} --output headset_priv.asc sig/headset_priv.asc.gpg
+        npm run sign:redhat
 
     - name: Testing app
       uses: GabrielBB/xvfb-action@v1.4

--- a/bin/installer/redhat_sign.sh
+++ b/bin/installer/redhat_sign.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+installers="build/installers"
+
+echo -e "\033[1mGPG import procedure:\033[01;0m"
+gpg2 --import headset_priv.asc
+echo 'digest-algo sha256' > "$HOME"/.gnupg/gpg.conf
+echo '%_gpg_name Headset' > "$HOME"/.rpmmacros
+echo -e 'Done'
+pwd
+echo -e "\n\033[1mSigning installer:\033[01;0m"
+rpm --addsign "$installers/headset-$VERSION-1.x86_64.rpm"
+echo -e 'Done'

--- a/bin/linux_repo.sh
+++ b/bin/linux_repo.sh
@@ -17,7 +17,6 @@ echo -e 'Done'
 
 echo -e "\n\033[1mCreating READHAT repository files:\033[01;0m"
 cp "$installers/headset-$VERSION-1.x86_64.rpm" $root/redhat
-rpm --addsign "$root/redhat/headset-$VERSION-1.x86_64.rpm"
 createrepo "$root/redhat"
 gpg --detach-sign --armor "$root/redhat/repodata/repomd.xml"
 echo -e 'Done'

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build:linux": "npm run pack:linux && npm run dist:linux",
     "build:darwin": "npm run pack:darwin && npm run dist:darwin",
     "build:windows": "npm run pack:windows && npm run dist:windows",
+    "sign:redhat": "VERSION=$npm_package_version bash bin/installer/redhat_sign.sh",
     "choco": "@powershell ./bin/build_choco.ps1 -version %npm_package_version%",
     "repo": "VERSION=$npm_package_version bash bin/linux_repo.sh",
     "test:app": "ava --timeout=20s test/app.test.js",


### PR DESCRIPTION
RedHat installer was only being signed for the repository, it should
always be signed for distribution.