### PR TITLE
fix: don't show error dialogs for updating errors

### DIFF
--- a/src/lib/autoUpdater.js
+++ b/src/lib/autoUpdater.js
@@ -1,27 +1,34 @@
 const { app, autoUpdater } = require('electron');
+const logger = require('./headsetLogger');
 
 const SERVER = 'https://update.electronjs.org';
 
 class AutoUpdater {
   constructor(options = {}) {
-    const feed = `${SERVER}/headsetapp/headset-electron/${process.platform}/${app.getVersion()}`;
+    const url = `${SERVER}/headsetapp/headset-electron/${process.platform}/${app.getVersion()}`;
 
-    autoUpdater.setFeedURL(feed);
+    autoUpdater.setFeedURL({ url });
 
     autoUpdater.on('update-downloaded', () => {
+      logger.update('Update downloaded');
       options.onUpdateDownloaded();
     });
 
-    // Check if app is installed with Squirrel
+    autoUpdater.on('error', (error) => {
+      logger.update(error); // don't show error dialog to users
+    });
+
+    // First run on start
     autoUpdater.checkForUpdates();
 
     setInterval(() => {
       autoUpdater.checkForUpdates();
-    }, 10 * 60 * 1000);
+    }, 60 * 60 * 1000); // check for updates every hour
   }
 
   /* eslint-disable class-methods-use-this */
   resetAndInstall() {
+    logger.update('Installing update');
     autoUpdater.quitAndInstall();
   }
   /* eslint-enable */

--- a/src/lib/headsetLogger.js
+++ b/src/lib/headsetLogger.js
@@ -5,6 +5,7 @@ const logger = debug('headset');
 const logDiscord = debug('headset:discord');
 const logMedia = debug('headset:media');
 const logTray = debug('headset:tray');
+const logUpdate = debug('headset:update');
 const logWin2Player = debug('headset:win2Player');
 const logPlayer2Win = debug('headset:player2Win');
 
@@ -35,6 +36,11 @@ class HeadsetLogger {
   static tray(message) {
     logTray(message);
     logFile.info(`headset:tray\t\t ${message}`);
+  }
+
+  static update(message) {
+    logUpdate(message);
+    logFile.info(`headset:update\t\t ${message}`);
   }
 
   static win2Player(message) {


### PR DESCRIPTION
Errors are still logged in the default file but users won't be disturbed by the dialog
fixes #395 