### PR TITLE
build: always package the latest code for husky pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,13 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+case $(uname -s) in
+  Linux*) os=linux;;
+  Darwin*) os=darwin;;
+  MINGW*) os=windows;;
+  *) echo OS not supported; exit 1;;
+esac
+
+npm run pack:${os}
+
 npm run test:app


### PR DESCRIPTION
The test was using whatever the build directory contained, which is not necessarily the latest code.
We now package the latest code before testing.