### PR TITLE
fix: always have a value for Discord start/end timestamps

### DIFF
--- a/src/lib/discord.js
+++ b/src/lib/discord.js
@@ -23,8 +23,8 @@ function setPresence() {
   const presence = {
     state: trackInfo.title,
     details: trackInfo.artist || '  ',
-    startTimestamp: start,
-    endTimestamp: end,
+    startTimestamp: start || 0,
+    endTimestamp: end || 0,
     instance: false,
     largeImageKey: 'playing',
     largeImageText: 'Headset',


### PR DESCRIPTION
For some reason, Date is returning null which causes RPC to error.
Fix #503