### PR TITLE
fix: always have a title for Discord

### DIFF
--- a/src/lib/discord.js
+++ b/src/lib/discord.js
@@ -21,7 +21,7 @@ function setPresence() {
 
   // See https://discord.com/developers/applications/712424004190732419/rich-presence/assets
   const presence = {
-    state: trackInfo.title,
+    state: trackInfo.title || '  ',
     details: trackInfo.artist || '  ',
     startTimestamp: start || 0,
     endTimestamp: end || 0,


### PR DESCRIPTION
It seems there are weird cases where Discord can crash, we are just covering our bases.